### PR TITLE
Add index based OMap operations

### DIFF
--- a/test/Data/Map/Ordered.purs
+++ b/test/Data/Map/Ordered.purs
@@ -1,0 +1,34 @@
+module Data.Map.Ordered.Spec
+  ( orderedMapSpec
+  ) where
+
+import Prelude
+
+import Data.Map.Ordered.OMap (fromFoldable, moveLeft, moveRight)
+import Data.Maybe (Maybe(..))
+import Data.Tuple.Nested ((/\))
+import Test.Spec (Spec, describe, it)
+import Test.Spec.Assertions (shouldEqual)
+
+orderedMapSpec :: Spec Unit
+orderedMapSpec = do
+  describe "moveLeft" do
+    it "fails on the first element" do
+      let
+        m = fromFoldable [ "foo" /\ 1, "bar" /\ 2, "baz" /\ 3 ]
+      moveLeft "foo" m `shouldEqual` Nothing
+    it "moves the second element" do
+      let
+        m = fromFoldable [ "foo" /\ 1, "bar" /\ 2, "baz" /\ 3 ]
+      moveLeft "bar" m `shouldEqual`
+        (Just $ fromFoldable [ "bar" /\ 2, "foo" /\ 1, "baz" /\ 3 ])
+  describe "moveRight" do
+    it "fails on the last element" do
+      let
+        m = fromFoldable [ "foo" /\ 1, "bar" /\ 2, "baz" /\ 3 ]
+      moveRight "baz" m `shouldEqual` Nothing
+    it "moves the second element" do
+      let
+        m = fromFoldable [ "foo" /\ 1, "bar" /\ 2, "baz" /\ 3 ]
+      moveRight "bar" m `shouldEqual`
+        (Just $ fromFoldable [ "foo" /\ 1, "baz" /\ 3, "bar" /\ 2 ])

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -6,6 +6,7 @@ import Data.Array.Extra.Spec (arrayExtraSpec)
 import Data.BigInt.Argonaut.Spec (bigIntSpec)
 import Data.Cursor.Spec (cursorSpec)
 import Data.Foldable.Extra.Spec (foldableExtraSpec)
+import Data.Map.Ordered.Spec (orderedMapSpec)
 import Data.String.Extra.Spec (stringExtraSpec)
 import Effect (Effect)
 import Effect.Aff (launchAff_)
@@ -23,3 +24,4 @@ main =
       stringExtraSpec
       assocMapSpec
       bigIntSpec
+      orderedMapSpec


### PR DESCRIPTION
I'm not sure if we want to clutter the API with helpers such as `moveLeft` and `moveRight`. I can drop them if we decide that they are not needed.