### PR TITLE
Fix infinite recursion for websocket

### DIFF
--- a/src/WebSocket/Support.purs
+++ b/src/WebSocket/Support.purs
@@ -227,9 +227,7 @@ runWebSocketManagerListeners uri manager = do
   reconnect = do
     void
       $ AVar.take (_.socket $ unWebSocketManager manager)
-      $ withHandler
-      $ const
-      $ runWebSocketManagerListeners uri manager
+      $ withHandler \_ -> runWebSocketManagerListeners uri manager
 
 withHandler :: forall a. (a -> Effect Unit) -> AVarCallback a
 withHandler _ (Left err) = log $ "Fatal websocket error: " <> show err


### PR DESCRIPTION
There seem to be a change between 0.13 and 0.14 on how they output the code, but there was an infinite recursion just by evaluating the reconnect.

![Screen Shot 2021-12-08 at 13 33 30](https://user-images.githubusercontent.com/2634059/145266469-b0e4f56c-1053-446f-87cd-44cb18c15c34.png)
